### PR TITLE
Enable to use path in the base_url by ensuring the api url is not prefixed with a /

### DIFF
--- a/osrm/client_async.py
+++ b/osrm/client_async.py
@@ -267,7 +267,7 @@ class OsrmAsyncClient():
         :return: Tile
         :rtype: ~model.OsrmTile
         """
-        url = f'/tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
+        url = f'tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
         osrm_res = await self._get(url)
         return model.OsrmTile(**osrm_res)
 

--- a/osrm/client_sync.py
+++ b/osrm/client_sync.py
@@ -266,7 +266,7 @@ class OsrmClient():
         :return: Tile
         :rtype: ~model.OsrmTile
         """
-        url = f'/tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
+        url = f'tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
         osrm_res = self._get(url)
         return model.OsrmTile(**osrm_res)
 

--- a/osrm/utils.py
+++ b/osrm/utils.py
@@ -31,7 +31,7 @@ def _build_osrm_url(
             return str(value)
 
     coord_str = ';'.join([f'{c[0]},{c[1]}' for c in coordinates])
-    url_base = f'/{service}/{api_version}/{profile}/{coord_str}'
+    url_base = f'{service}/{api_version}/{profile}/{coord_str}'
     url_params = '&'.join(
         f'{key}={_query_param(value)}'
         for key, value in kwargs.items()


### PR DESCRIPTION
Closes #4 