### PR TITLE
Add table distances

### DIFF
--- a/osrm/client_async.py
+++ b/osrm/client_async.py
@@ -267,7 +267,7 @@ class OsrmAsyncClient():
         :return: Tile
         :rtype: ~model.OsrmTile
         """
-        url = f'/tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
+        url = f'tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
         osrm_res = await self._get(url)
         return model.OsrmTile(**osrm_res)
 

--- a/osrm/client_async.py
+++ b/osrm/client_async.py
@@ -267,7 +267,7 @@ class OsrmAsyncClient():
         :return: Tile
         :rtype: ~model.OsrmTile
         """
-        url = f'tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
+        url = f'/tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
         osrm_res = await self._get(url)
         return model.OsrmTile(**osrm_res)
 

--- a/osrm/client_async.py
+++ b/osrm/client_async.py
@@ -118,10 +118,11 @@ class OsrmAsyncClient():
             profile: Optional[str] = None,
             sources: List[int] = [],
             destinations: List[int] = [],
+            annotations: List[str] = [],
     ) -> model.OsrmTable:
         """OSRM Table service.
 
-        Computes the duration of the fastest route between all pairs
+        Computes the duration and/or distance of the fastest route between all pairs
         of supplied coordinates.
 
         See https://project-osrm.org/docs/v5.24.0/api/#table-service
@@ -130,17 +131,20 @@ class OsrmAsyncClient():
         :keyword profile: OSRM Profile, defaults to client default.
         :keyword sources: Use location with given index as source.
         :keyword destinations: Use location with given index as destination.
+        :keyword annotations: Return the requested table or tables in response.
 
-        :return: Distance table computed by OSRM.
+        :return: Duration and/or distance table computed by OSRM.
         :rtype: ~model.OsrmTable
         """
         sources_str = ";".join(sources) if sources else "all"
         destinations_str = ";".join(destinations) if destinations else "all"
+        annotations_str = ",".join(annotations) if annotations else "duration"
 
         osrm_res = await self._osrm_service(
             'table', profile, coordinates,
             sources=sources_str,
             destinations=destinations_str,
+            annotations=annotations_str,
         )
         return model.OsrmTable(**osrm_res)
 

--- a/osrm/client_sync.py
+++ b/osrm/client_sync.py
@@ -119,6 +119,7 @@ class OsrmClient():
             profile: Optional[str] = None,
             sources: List[int] = [],
             destinations: List[int] = [],
+            annotations: List[str] = [],
     ) -> model.OsrmTable:
         """OSRM Table service.
 
@@ -137,11 +138,13 @@ class OsrmClient():
         """
         sources_str = ";".join(sources) if sources else "all"
         destinations_str = ";".join(destinations) if destinations else "all"
+        annotations_str = ",".join(annotations) if annotations else "duration"
 
         osrm_res = self._osrm_service(
             'table', profile, coordinates,
             sources=sources_str,
             destinations=destinations_str,
+            annotations=annotations_str,
         )
         return model.OsrmTable(**osrm_res)
 

--- a/osrm/client_sync.py
+++ b/osrm/client_sync.py
@@ -123,7 +123,7 @@ class OsrmClient():
     ) -> model.OsrmTable:
         """OSRM Table service.
 
-        Computes the duration of the fastest route between all pairs
+        Computes the duration and/or distance of the fastest route between all pairs
         of supplied coordinates.
 
         See https://project-osrm.org/docs/v5.24.0/api/#table-service
@@ -132,8 +132,9 @@ class OsrmClient():
         :keyword profile: OSRM Profile, defaults to client default.
         :keyword sources: Use location with given index as source.
         :keyword destinations: Use location with given index as destination.
+        :keyword annotations: Return the requested table or tables in response.
 
-        :return: Distance table computed by OSRM.
+        :return: Duration and/or distance table computed by OSRM.
         :rtype: ~model.OsrmTable
         """
         sources_str = ";".join(sources) if sources else "all"

--- a/osrm/client_sync.py
+++ b/osrm/client_sync.py
@@ -266,7 +266,7 @@ class OsrmClient():
         :return: Tile
         :rtype: ~model.OsrmTile
         """
-        url = f'/tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
+        url = f'tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
         osrm_res = self._get(url)
         return model.OsrmTile(**osrm_res)
 

--- a/osrm/client_sync.py
+++ b/osrm/client_sync.py
@@ -269,7 +269,7 @@ class OsrmClient():
         :return: Tile
         :rtype: ~model.OsrmTile
         """
-        url = f'tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
+        url = f'/tile/{self.api_version}/driving/({x},{y},{zoom}).mvt'
         osrm_res = self._get(url)
         return model.OsrmTile(**osrm_res)
 

--- a/osrm/model.py
+++ b/osrm/model.py
@@ -242,12 +242,14 @@ class OsrmTable(ServiceResponse):
     See https://project-osrm.org/docs/v5.24.0/api/#table-service
     """
     durations: List[List[float]]
+    distances: List[List[float]]
     sources: List[Waypoint]
     destinations: List[Waypoint]
 
     def __init__(self, **data):
         super().__init__(data["code"])
-        self.durations = data["durations"]
+        self.durations = data["durations"] if "durations" in data else []
+        self.distances = data["distances"] if "distances" in data else []
         self.sources = [Waypoint(**wp) for wp in data["sources"]]
         self.destinations = [Waypoint(**wp) for wp in data["destinations"]]
 

--- a/osrm/utils.py
+++ b/osrm/utils.py
@@ -31,7 +31,7 @@ def _build_osrm_url(
             return str(value)
 
     coord_str = ';'.join([f'{c[0]},{c[1]}' for c in coordinates])
-    url_base = f'/{service}/{api_version}/{profile}/{coord_str}'
+    url_base = f'{service}/{api_version}/{profile}/{coord_str}'
     url_params = '&'.join(
         f'{key}={_query_param(value)}'
         for key, value in kwargs.items()

--- a/osrm/utils.py
+++ b/osrm/utils.py
@@ -31,7 +31,7 @@ def _build_osrm_url(
             return str(value)
 
     coord_str = ';'.join([f'{c[0]},{c[1]}' for c in coordinates])
-    url_base = f'{service}/{api_version}/{profile}/{coord_str}'
+    url_base = f'/{service}/{api_version}/{profile}/{coord_str}'
     url_params = '&'.join(
         f'{key}={_query_param(value)}'
         for key, value in kwargs.items()


### PR DESCRIPTION
The [OSRM table service](https://project-osrm.org/docs/v5.24.0/api/#table-service) can output durations or distances. This pull request adds the possibility to specify which of these outputs is desired using the `annotations` parameter.